### PR TITLE
fixes

### DIFF
--- a/lua/flygrep.lua
+++ b/lua/flygrep.lua
@@ -400,6 +400,9 @@ local function open_win()
     local line_number = vim.api.nvim_win_get_cursor(result_winid)[1]
     local filename, linenr, colum =
       get_file_pos(vim.api.nvim_buf_get_lines(result_bufid, line_number - 1, line_number, false)[1])
+    if not filename or not linenr or not colum then
+      return
+    end
     vim.api.nvim_win_close(prompt_winid, true)
     vim.api.nvim_buf_set_lines(prompt_bufid, 0, -1, false, {})
     vim.api.nvim_win_close(result_winid, true)

--- a/lua/flygrep.lua
+++ b/lua/flygrep.lua
@@ -331,6 +331,7 @@ local function open_win()
     { win = result_winid }
   )
   vim.api.nvim_set_option_value('cursorline', true, { win = result_winid })
+  vim.api.nvim_set_option_value('cursorlineopt', 'both', { win = result_winid })
   if ok then
     cmp.setup.buffer({
       completion = {

--- a/lua/flygrep.lua
+++ b/lua/flygrep.lua
@@ -252,6 +252,7 @@ local function open_win()
   local screen_height = math.floor(vim.o.lines * 0.8)
 
   prompt_bufid = vim.api.nvim_create_buf(false, true)
+  vim.b[prompt_bufid].completion = false -- https://github.com/Saghen/blink.cmp/commit/79545c371ab08cf4563fffb9f5c7a7c9e8fbc786
   prompt_winid = vim.api.nvim_open_win(prompt_bufid, true, {
     relative = 'editor',
     width = screen_width,


### PR DESCRIPTION
- **fix: disable blink.cmp on prompt win**
- **fix: avoid overriden by global 'cursorlineopt'**
- **fix: when enter no entry matched**
